### PR TITLE
[callrecorderd] OFonoManager init will be async in future Sailfish OS re...

### DIFF
--- a/daemon/src/application.cpp
+++ b/daemon/src/application.cpp
@@ -111,6 +111,7 @@ Application::Application(int argc, char* argv[])
 
     d->qofonoManager.reset(new QOfonoManager());
 
+    while (!d->qofonoManager->available()) QThread::sleep(1);
     if (!d->qofonoManager->available())
         throw CallRecorderException(QLatin1String("Ofono is not available!"));
 

--- a/rpm/harbour-callrecorder.spec
+++ b/rpm/harbour-callrecorder.spec
@@ -42,6 +42,7 @@ BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions) >= 0.2.1
 BuildRequires:  nemo-qml-plugin-dbus-qt5
 BuildRequires:  qtcontacts-sqlite-qt5
 BuildRequires:  desktop-file-utils
+BuildRequires:  libsailfishapp-devel
 
 %description
 Simple call recorder for SailfishOS

--- a/rpm/harbour-callrecorder.yaml
+++ b/rpm/harbour-callrecorder.yaml
@@ -40,6 +40,7 @@ PkgConfigBR:
 PkgBR:
    - nemo-qml-plugin-dbus-qt5
    - qtcontacts-sqlite-qt5
+   - libsailfishapp-devel
 
 # Runtime dependencies which are not automatically detected
 Requires:


### PR DESCRIPTION
...leases

Available signal will only happen when modem has been added:
https://github.com/nemomobile/libqofono/commit/28fe362407cdbb3f6be6261e4c1e26e39f846e2f

So in current code throw is always called with "Ofono is not available!" when running for example latest internal developer branch.

Alternative way would be just to remove the available throw check and only wait for availableChanged/ModemAdded-signal.