### PR TITLE
Fixed deletion of all media

### DIFF
--- a/libcallrecorder/src/eventstablemodel.cpp
+++ b/libcallrecorder/src/eventstablemodel.cpp
@@ -283,7 +283,7 @@ private:
                 foreach (QString file, files)
                 {
                     qDebug() << "removing" << file;
-                    QFile(file).remove();
+                    QQFile(outputLocationDir.filePath(file)).remove();
                 }
             }
             else


### PR DESCRIPTION
This is a fix for the "Delete all" function, when deleting recordings without any filters. I mentioned the problem in #40 Now it cleans up the folder as expected. 