### PR TITLE
Change wanted-by target of daemon to post-user-session

### DIFF
--- a/daemon/harbour-callrecorderd.service
+++ b/daemon/harbour-callrecorderd.service
@@ -12,4 +12,4 @@ Restart=on-failure
 EnvironmentFile=-/home/nemo/.config/harbour-callrecorder/environment
 
 [Install]
-WantedBy=user-session.target
+WantedBy=post-user-session.target

--- a/rpm/harbour-callrecorder.spec
+++ b/rpm/harbour-callrecorder.spec
@@ -79,7 +79,6 @@ systemctl-user daemon-reload
 # install
 if [ $1 = 1 ]; then
     echo "Enabling service..."
-    mkdir -p /home/nemo/.config/systemd/user/user-session.target.wants
     chown --recursive nemo:nemo /home/nemo/.config/systemd
 
     systemctl-user enable harbour-callrecorderd


### PR DESCRIPTION
Delaying daemon startup to later stage makes sure that environment is
properly initialized. For instance, wayland might be unavailable yet if
a daemon is started by `user-session.target`.

Fixes #51

I've removed creation of
~/.config/systemd/user/user-session.target.wants
from spec as systemctl creates missing ${target}.wants if it is missing
and it is not clear why mkdir was added in first place.